### PR TITLE
doc: add mention of AUR package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ fx. `~/.local/bin`.
 Then insert/replace keybinds to run `exec sway-overfocus ...` commands
 in your sway configuration.
 
+If you use the pacman package manager, an AUR package with the name [`sway-overfocus`](https://aur.archlinux.org/packages/sway-overfocus) is available as well.
+Note that the package is not maintained by the original author of the software.
+
 See the [usage](usage.md) page for details on constructing focus commands.
 The following config section is a good starting point,
 but commands can be configured granularly to suit your needs.


### PR DESCRIPTION
Hey,

I have created an Arch User Repository (AUR) package for this repository under the name [`sway-overfocus`](https://aur.archlinux.org/packages/sway-overfocus). Software from the AUR is very convenient to install for users of the pacman package manager (which is the default for Arch Linux and Manjaro) over an installation from source. The package currently tracks the 0.2.3 version, [as given by the tag](https://github.com/korreman/sway-overfocus/releases/tag/v0.2.3).
Feel free to add a mention to this package to the README if you would like.

**Note:** While creating the package, I noticed that the package versions for sway-overfocus differ in the `Cargo.toml` (0.2.3) and `Cargo.lock` (0.2.2) files. I currently circumvent this issue in the build process by using `sed` to adjust the version in the lockfile. Please let me know if this intended or if you plan to fix this discrepancy.

---

In case you never heard of the AUR, let me quote from the [Arch Linux wiki](https://wiki.archlinux.org/title/Arch_User_Repository):
> The Arch User Repository (AUR) is a community-driven repository for Arch users. It contains package descriptions that allow you to compile a package from source with makepkg and then install it via pacman. The AUR was created to organize and share new packages from the community and to help expedite popular packages' inclusion into the community repository.

---

In case you have any questions or concerns, or would like me to take the package down, please let me know. Thank you for providing this great piece of software!